### PR TITLE
Updates related to Jackson v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can deploy SAML Jackson as a separate service. [Check out the documentation 
 
 SAML login requires a configuration for every tenant of yours. One common method is to use the domain for an email address to figure out which tenant they belong to. You can also use a unique tenant ID (string) from your backend for this, typically some kind of account or organization ID.
 
-Check out the [documentation](https://boxyhq.com/docs/jackson/saml-flow#2-saml-config-api) for more details.
+Check out the [documentation](https://boxyhq.com/docs/jackson/sso-flow/#21-add-connection) for more details.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Checkout the demo at https://github.com/boxyhq/jackson-remix-auth
 
 ## SAML Jackson Service
 
-SAML Jackson implements SSO as an OAuth 2.0 or OpenID Connect flow, abstracting away all the complexities of the underlying SAML/OIDC protocol.
+SAML Jackson implements SSO as an OAuth 2.0 flow, abstracting away all the complexities of the underlying SAML/OIDC protocol.
 
 You can deploy SAML Jackson as a separate service. [Check out the documentation for more details](https://boxyhq.com/docs/jackson/deploy)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Checkout the demo at https://github.com/boxyhq/jackson-remix-auth
 
 ## SAML Jackson Service
 
-SAML Jackson is an open source service that handles the SAML login flow as an OAuth 2.0 flow, abstracting away all the complexities of the SAML protocol.
+SAML Jackson is an open-source service that handles the SAML login flow as an OAuth 2.0 flow, abstracting away all the complexities of the SAML protocol.
 
 You can deploy SAML Jackson as a separate service. [Check out the documentation for more details](https://boxyhq.com/docs/jackson/deploy)
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 The BoxyHQ SAML strategy can be used to enable SAML login in your remix app. It extends the OAuth2Strategy.
 
 # Demo
+
 Checkout the demo at https://github.com/boxyhq/jackson-remix-auth
 
 ## Supported runtimes
@@ -27,12 +28,15 @@ SAML login requires a configuration for every tenant of yours. One common method
 Check out the [documentation](https://boxyhq.com/docs/jackson/saml-flow#2-saml-config-api) for more details.
 
 ## Usage
+
 ### Install the strategy
+
 ```bash
 npm install @boxyhq/remix-auth-saml
 ```
 
 ### Create the strategy instance
+
 ```ts
 // app/utils/auth.server.ts
 import { Authenticator } from "remix-auth";
@@ -43,8 +47,9 @@ import {
 
 // Create an instance of the authenticator, pass a generic with what your
 // strategies will return and will be stored in the session
-export const authenticator = new Authenticator<BoxyHQSAMLProfile>(sessionStorage);
-
+export const authenticator = new Authenticator<BoxyHQSAMLProfile>(
+  sessionStorage
+);
 
 auth.use(
   new BoxyHQSAMLStrategy(
@@ -52,7 +57,10 @@ auth.use(
       issuer: "http://localhost:5225", // point this to the hosted jackson service
       clientID: "dummy", // The dummy here is necessary if the tenant and product are set dynamically from the client side
       clientSecret: "dummy", // The dummy here is necessary if the tenant and product are set dynamically from the client side
-      callbackURL: new URL("/auth/saml/callback", process.env.BASE_URL).toString(), // BASE_URL should point to the application URL
+      callbackURL: new URL(
+        "/auth/saml/callback",
+        process.env.BASE_URL
+      ).toString(), // BASE_URL should point to the application URL
     },
     async ({ profile }) => {
       return profile;
@@ -67,10 +75,7 @@ auth.use(
 // app/routes/login.tsx
 export default function Login() {
   return (
-    <Form
-      method="post"
-      action="/auth/saml"
-    >
+    <Form method="post" action="/auth/saml">
       {/* We will be using user email to identify the tenant*/}
       <label htmlFor="email">Email</label>
       <input
@@ -82,13 +87,10 @@ export default function Login() {
       />
       {/* Product can also be set dynamically, set to `demo` here */}
       <input type="text" name="product" hidden defaultValue="demo" />
-      <button type="submit">
-        Sign In with SSO
-      </button>
+      <button type="submit">Sign In with SSO</button>
     </Form>
   );
 }
-
 ```
 
 ```tsx
@@ -140,5 +142,4 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     failureRedirect: "/",
   });
 };
-
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Checkout the demo at https://github.com/boxyhq/jackson-remix-auth
 
 ## SAML Jackson Service
 
-SAML Jackson implements SSO as an OAuth 2.0 flow, abstracting away all the complexities of the underlying SAML/OIDC protocol.
+SAML Jackson implements SSO as an OAuth 2.0 or OpenID Connect flow, abstracting away all the complexities of the underlying SAML/OIDC protocol.
 
 You can deploy SAML Jackson as a separate service. [Check out the documentation for more details](https://boxyhq.com/docs/jackson/deploy)
 
@@ -60,7 +60,7 @@ auth.use(
       clientID: "dummy", // The dummy here is necessary if the tenant and product are set dynamically from the client side
       clientSecret: "dummy", // The dummy here is necessary if the tenant and product are set dynamically from the client side
       callbackURL: new URL(
-        "/auth/saml/callback",
+        "/auth/sso/callback",
         process.env.BASE_URL
       ).toString(), // BASE_URL should point to the application URL
     },

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # BoxyHQSSOStrategy
 
-The BoxyHQ SSO strategy can be used to enable Single Sign-On (SSO) in your remix app. It extends the OAuth2Strategy.
+**Attention ⚠️**: We have deprecated the earlier strategy `BoxyHQSAMLStrategy` (npm package: `@boxyhq/remix-auth-saml`). In case you are using that one please consider changing over to this strategy.
+
+The BoxyHQSSOStrategy can be used to enable Single Sign-On (SSO) in your remix app. It extends the OAuth2Strategy.
 
 # Demo
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# BoxyHQSAMLStrategy
+# BoxyHQSSOStrategy
 
-The BoxyHQ SAML strategy can be used to enable SAML login in your remix app. It extends the OAuth2Strategy.
+The BoxyHQ SSO strategy can be used to enable Single Sign-On (SSO) in your remix app. It extends the OAuth2Strategy.
 
 # Demo
 
@@ -17,13 +17,13 @@ Checkout the demo at https://github.com/boxyhq/jackson-remix-auth
 
 ## SAML Jackson Service
 
-SAML Jackson is an open-source service that handles the SAML login flow as an OAuth 2.0 flow, abstracting away all the complexities of the SAML protocol.
+SAML Jackson implements SSO as an OAuth 2.0 flow, abstracting away all the complexities of the underlying SAML/OIDC protocol.
 
 You can deploy SAML Jackson as a separate service. [Check out the documentation for more details](https://boxyhq.com/docs/jackson/deploy)
 
 ## Configuration
 
-SAML login requires a configuration for every tenant of yours. One common method is to use the domain for an email address to figure out which tenant they belong to. You can also use a unique tenant ID (string) from your backend for this, typically some kind of account or organization ID.
+SSO login requires a connection for every tenant/product of yours. One common method is to use the domain for an email address to figure out which tenant they belong to. You can also use a unique tenant ID (string) from your backend for this, typically some kind of account or organization ID.
 
 Check out the [documentation](https://boxyhq.com/docs/jackson/sso-flow/#21-add-connection) for more details.
 
@@ -32,7 +32,7 @@ Check out the [documentation](https://boxyhq.com/docs/jackson/sso-flow/#21-add-c
 ### Install the strategy
 
 ```bash
-npm install @boxyhq/remix-auth-saml
+npm install @boxyhq/remix-auth-sso
 ```
 
 ### Create the strategy instance
@@ -41,18 +41,18 @@ npm install @boxyhq/remix-auth-saml
 // app/utils/auth.server.ts
 import { Authenticator } from "remix-auth";
 import {
-  BoxyHQSAMLStrategy,
-  type BoxyHQSAMLProfile,
+  BoxyHQSSOStrategy,
+  type BoxyHQSSOProfile,
 } from "@boxyhq/remix-auth-saml";
 
 // Create an instance of the authenticator, pass a generic with what your
 // strategies will return and will be stored in the session
-export const authenticator = new Authenticator<BoxyHQSAMLProfile>(
+export const authenticator = new Authenticator<BoxyHQSSOProfile>(
   sessionStorage
 );
 
 auth.use(
-  new BoxyHQSAMLStrategy(
+  new BoxyHQSSOStrategy(
     {
       issuer: "http://localhost:5225", // point this to the hosted jackson service
       clientID: "dummy", // The dummy here is necessary if the tenant and product are set dynamically from the client side
@@ -75,7 +75,7 @@ auth.use(
 // app/routes/login.tsx
 export default function Login() {
   return (
-    <Form method="post" action="/auth/saml">
+    <Form method="post" action="/auth/sso">
       {/* We will be using user email to identify the tenant*/}
       <label htmlFor="email">Email</label>
       <input
@@ -94,7 +94,7 @@ export default function Login() {
 ```
 
 ```tsx
-// app/routes/auth/saml.tsx
+// app/routes/auth/sso.tsx
 import { ActionFunction, json } from "remix";
 import { auth } from "~/auth.server";
 import invariant from "tiny-invariant";
@@ -120,7 +120,7 @@ export const action: ActionFunction = async ({ request }) => {
   invariant(typeof email === "string");
   // Get the tenant from the domain
   const tenant = email.split("@")[1];
-  return await auth.authenticate("boxyhq-saml", request, {
+  return await auth.authenticate("boxyhq-sso", request, {
     successRedirect: "/private",
     failureRedirect: "/",
     context: {
@@ -132,12 +132,12 @@ export const action: ActionFunction = async ({ request }) => {
 ```
 
 ```tsx
-// app/routes/auth/saml/callback.tsx
+// app/routes/auth/sso/callback.tsx
 import type { LoaderFunction } from "remix";
 import { auth } from "~/auth.server";
 
 export const loader: LoaderFunction = async ({ request, params }) => {
-  return auth.authenticate("boxyhq-saml", request, {
+  return auth.authenticate("boxyhq-sso", request, {
     successRedirect: "/private",
     failureRedirect: "/",
   });

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import { Authenticator } from "remix-auth";
 import {
   BoxyHQSSOStrategy,
   type BoxyHQSSOProfile,
-} from "@boxyhq/remix-auth-saml";
+} from "@boxyhq/remix-auth-sso";
 
 // Create an instance of the authenticator, pass a generic with what your
 // strategies will return and will be stored in the session

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@boxyhq/remix-auth-saml",
+  "name": "@boxyhq/remix-auth-sso",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@boxyhq/remix-auth-saml",
+      "name": "@boxyhq/remix-auth-sso",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/boxyhq/remix-auth-sso"
   },
-  "description": "A SSO strategy for Remix Auth, based on the OAuth2Strategy",
+  "description": "An SSO strategy for Remix Auth, based on the OAuth2Strategy",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@boxyhq/remix-auth-saml",
+  "name": "@boxyhq/remix-auth-sso",
   "version": "1.0.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/boxyhq/remix-auth-saml"
+    "url": "https://github.com/boxyhq/remix-auth-sso"
   },
-  "description": "A SAML strategy for Remix Auth, based on the OAuth2Strategy",
+  "description": "A SSO strategy for Remix Auth, based on the OAuth2Strategy",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "scripts": {
@@ -22,7 +22,8 @@
     "authentication",
     "strategy",
     "saml2",
-    "oauth2"
+    "oauth2",
+    "openid-connect"
   ],
   "author": {
     "name": "BoxyHQ",

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,14 +65,6 @@ export class BoxyHQSSOStrategy<User> extends OAuth2Strategy<
     return super.authenticate(request, sessionStorage, options);
   }
 
-  protected authorizationParams(): URLSearchParams {
-    const urlSearchParams: Record<string, string> = {
-      provider: "saml",
-    };
-
-    return new URLSearchParams(urlSearchParams);
-  }
-
   protected async userProfile(accessToken: string): Promise<BoxyHQSSOProfile> {
     let response = await fetch(this.userInfoURL, {
       headers: { Authorization: `Bearer ${accessToken}` },

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,9 @@ export interface BoxyHQSSOStrategyOptions {
 export interface BoxyHQSSOProfile extends OAuth2Profile {
   id: string;
   email: string;
-  firstName?: string;
-  lastName?: string;
+  firstName: string;
+  lastName: string;
+  requested: Record<string, string>;
 }
 
 export class BoxyHQSSOStrategy<User> extends OAuth2Strategy<

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,33 +10,33 @@ import {
  * This interface declares what configuration the strategy needs from the
  * developer to correctly work.
  */
-export interface BoxyHQSAMLStrategyOptions {
+export interface BoxyHQSSOStrategyOptions {
   issuer: string;
   clientID: string;
   clientSecret: string;
   callbackURL: string;
 }
 
-export interface BoxyHQSAMLProfile extends OAuth2Profile {
+export interface BoxyHQSSOProfile extends OAuth2Profile {
   id: string;
   email: string;
   firstName?: string;
   lastName?: string;
 }
 
-export class BoxyHQSAMLStrategy<User> extends OAuth2Strategy<
+export class BoxyHQSSOStrategy<User> extends OAuth2Strategy<
   User,
-  BoxyHQSAMLProfile,
+  BoxyHQSSOProfile,
   never
 > {
-  name = "boxyhq-saml";
+  name = "boxyhq-sso";
   private userInfoURL: string;
 
   constructor(
-    options: BoxyHQSAMLStrategyOptions,
+    options: BoxyHQSSOStrategyOptions,
     verify: StrategyVerifyCallback<
       User,
-      OAuth2StrategyVerifyParams<BoxyHQSAMLProfile, never>
+      OAuth2StrategyVerifyParams<BoxyHQSSOProfile, never>
     >
   ) {
     super(
@@ -73,14 +73,14 @@ export class BoxyHQSAMLStrategy<User> extends OAuth2Strategy<
     return new URLSearchParams(urlSearchParams);
   }
 
-  protected async userProfile(accessToken: string): Promise<BoxyHQSAMLProfile> {
+  protected async userProfile(accessToken: string): Promise<BoxyHQSSOProfile> {
     let response = await fetch(this.userInfoURL, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
 
-    let data: BoxyHQSAMLProfile = await response.json();
+    let data: BoxyHQSSOProfile = await response.json();
 
-    let profile: BoxyHQSAMLProfile = {
+    let profile: BoxyHQSSOProfile = {
       ...data,
       provider: this.name,
     };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -91,7 +91,6 @@ describe(BoxyHQSSOStrategy, () => {
       let redirectUrl = new URL(location);
       expect(redirectUrl.hostname).toBe("jackson-demo.boxyhq.com");
       expect(redirectUrl.pathname).toBe("/api/oauth/authorize");
-      expect(redirectUrl.searchParams.get("provider")).toBe(`saml`);
     }
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,7 @@
 import { createCookieSessionStorage } from "@remix-run/server-runtime";
-import { BoxyHQSAMLStrategy } from "../src";
+import { BoxyHQSSOStrategy } from "../src";
 
-describe(BoxyHQSAMLStrategy, () => {
+describe(BoxyHQSSOStrategy, () => {
   let verify = jest.fn();
   // You will probably need a sessionStorage to test the strategy.
   let sessionStorage = createCookieSessionStorage({
@@ -19,13 +19,13 @@ describe(BoxyHQSAMLStrategy, () => {
     jest.resetAllMocks();
   });
 
-  test("should have the name of the `boxyhq-saml`", () => {
-    const strategy = new BoxyHQSAMLStrategy(options, verify);
-    expect(strategy.name).toBe("boxyhq-saml");
+  test("should have the name of the `boxyhq-sso`", () => {
+    const strategy = new BoxyHQSSOStrategy(options, verify);
+    expect(strategy.name).toBe("boxyhq-sso");
   });
 
   test("should allow setting the clientID/Secret from the options", async () => {
-    const strategy = new BoxyHQSAMLStrategy(options, verify);
+    const strategy = new BoxyHQSSOStrategy(options, verify);
 
     const request = new Request("https://example.app/auth/boxy-saml");
     try {
@@ -46,7 +46,7 @@ describe(BoxyHQSAMLStrategy, () => {
   });
 
   test("should allow setting the clientID/Secret dynamically from the context", async () => {
-    const strategy = new BoxyHQSAMLStrategy(options, verify);
+    const strategy = new BoxyHQSSOStrategy(options, verify);
 
     const request = new Request("https://example.app/auth/boxy-saml");
     try {
@@ -73,7 +73,7 @@ describe(BoxyHQSAMLStrategy, () => {
   });
 
   test("should correctly format the authorization URL", async () => {
-    const strategy = new BoxyHQSAMLStrategy(options, verify);
+    const strategy = new BoxyHQSSOStrategy(options, verify);
 
     const request = new Request("https://example.app/auth/boxy-saml");
     try {


### PR DESCRIPTION
With this change we can deprecate current npm package `@boxyhq/remix-auth-saml`. The new package will be published as `@boxyhq/remix-auth-sso`.